### PR TITLE
iOS 7 random crash bug fixing

### DIFF
--- a/Classes/EMCCountryPickerController.m
+++ b/Classes/EMCCountryPickerController.m
@@ -416,4 +416,14 @@ static const CGFloat kEMCCountryCellControllerMinCellHeight = 25;
     _countries = [availableCountries sortedArrayUsingDescriptors:descriptors];
 }
 
+-(void)dealloc
+{
+    countryTable.delegate = nil;
+    countryTable.dataSource = nil;
+    searchBar.delegate = nil;
+    
+    displayController.searchResultsDelegate = nil;
+    displayController.searchResultsDataSource = nil;
+}
+
 @end


### PR DESCRIPTION
Randomly crashes (i could reproduce this bug in iOS7 but i am not sure) because delegates are not properly released after controller dismissal.