### PR TITLE
Correct the spelling of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ a country's flag is shown at the left of the country name.
 Prerequisites
 -------------
 
-This library has been built with XCode 5.1.1 using iOS 7.1 as a build target.
+This library has been built with Xcode 5.1.1 using iOS 7.1 as a build target.
 This library requires iOS >= 6.1.
 
 This library requires [ARC][arc] (_Automatic Reference Counting_) and


### PR DESCRIPTION

This pull request corrects the spelling of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
